### PR TITLE
som-73_create-user-fields-arent-cleared-upon-creation

### DIFF
--- a/src/pages/administerUsersPage.vue
+++ b/src/pages/administerUsersPage.vue
@@ -295,6 +295,8 @@ export default {
         data.notificationMessage = "Bruger med navnet: '" + nameCreate.value + "' oprettet"
         users.value.push(newUserCreated)
         showPopupCreate.value = false
+        nameCreate.value = ""
+        emailCreate.value = ""
       }
       notificationBanner.value.displayNotification(data.notificationMessage, data.type)
     }


### PR DESCRIPTION
+ administerUsersPage.vue: clearing of creation values when clicking create